### PR TITLE
fix: killing descendants

### DIFF
--- a/examples/hotreload/api/.pw.yml
+++ b/examples/hotreload/api/.pw.yml
@@ -21,7 +21,6 @@ watchers:
       timeout: 3s
     cmd: 
       shell: /bin/sh -c
-      exec: dlv debug --headless -l :2345 --api-version=2 --accept-multiclient --log --continue ./cmd/api
-      env: 
-        - GO111MODULE=off
-
+      exec: go mod tidy; dlv debug --headless -l :2345 --api-version=2 --accept-multiclient --log --continue ./cmd/api
+      env:
+        - LOG_LEVEL=DEBUG

--- a/examples/hotreload/api/.pw.yml
+++ b/examples/hotreload/api/.pw.yml
@@ -21,6 +21,7 @@ watchers:
       timeout: 3s
     cmd: 
       shell: /bin/sh -c
-      exec: go mod tidy; dlv debug --headless -l :2345 --api-version=2 --accept-multiclient --log --continue ./cmd/api
+      exec: >
+        go mod tidy; dlv debug --headless -l :2345 --api-version=2 --accept-multiclient --log --continue ./cmd/api
       env:
         - LOG_LEVEL=DEBUG

--- a/examples/hotreload/docker-compose.yml
+++ b/examples/hotreload/docker-compose.yml
@@ -7,8 +7,9 @@ services:
     image: registry.ronaksoft.com/library/golang:dev
     entrypoint:
       - /bin/sh
-    command: >
-      -c "(cd /go/src/github.com/pouyanh/polywatch/cmd/polywatch; go mod tidy; go build -o /bin/polywatch); /bin/polywatch"
+      - -c
+    command:
+      - (cd /go/src/github.com/pouyanh/polywatch/cmd/polywatch; go mod tidy; go build -o /bin/polywatch); /bin/polywatch
     healthcheck:
       test:
         - "CMD"

--- a/examples/hotreload/docker-compose.yml
+++ b/examples/hotreload/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     entrypoint:
       - /bin/sh
     command: >
-      -c "(cd /go/src/github.com/saman3d/polywatch/cmd/polywatch; go mod tidy; go build -o /bin/polywatch); /bin/polywatch"
+      -c "(cd /go/src/github.com/pouyanh/polywatch/cmd/polywatch; go mod tidy; go build -o /bin/polywatch); /bin/polywatch"
     healthcheck:
       test:
         - "CMD"
@@ -27,7 +27,7 @@ services:
       - "apparmor=unconfined"
     cap_add:
       - SYS_PTRACE
-    working_dir: /go/src/github.com/saman3d/polywatch/examples/hotreload/api
+    working_dir: /go/src/github.com/pouyanh/polywatch/examples/hotreload/api
     volumes:
       - gosrc:/go/src
       - gomod:/go/pkg/mod

--- a/examples/hotreload/docker-compose.yml
+++ b/examples/hotreload/docker-compose.yml
@@ -6,10 +6,9 @@ services:
       context: context/go
     image: registry.ronaksoft.com/library/golang:dev
     entrypoint:
-      - go
-    command:
-      - run
-      - /go/src/github.com/pouyanh/polywatch/cmd/polywatch/main.go
+      - /bin/sh
+    command: >
+      -c "(cd /go/src/github.com/saman3d/polywatch/cmd/polywatch; go mod tidy; go build -o /bin/polywatch); /bin/polywatch"
     healthcheck:
       test:
         - "CMD"
@@ -28,15 +27,14 @@ services:
       - "apparmor=unconfined"
     cap_add:
       - SYS_PTRACE
-    working_dir: /go/src/github.com/pouyanh/polywatch/examples/hotreload/api
+    working_dir: /go/src/github.com/saman3d/polywatch/examples/hotreload/api
     volumes:
       - gosrc:/go/src
-      # - gomod:/go/pkg/mod
+      - gomod:/go/pkg/mod
       - /etc/localtime:/etc/localtime:ro
     environment:
       HOSTNAME: api.hotreload.plw
 
-      GO111MODULE: off
       GOPRIVATE: github.com/pouyanh*,github.com/janstoon*
 
 volumes:

--- a/polywatch.go
+++ b/polywatch.go
@@ -7,8 +7,10 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/radovskyb/watcher"
 	"github.com/zmwangx/debounce"
@@ -41,6 +43,15 @@ func Start() error {
 			}
 		}()
 	}
+
+	cchan := make(chan os.Signal)
+	signal.Notify(cchan, syscall.SIGTERM, syscall.SIGINT)
+
+	go func() {
+		<-cchan
+
+		stop()
+	}()
 
 	wg.Wait()
 

--- a/polywatch.go
+++ b/polywatch.go
@@ -44,18 +44,21 @@ func Start() error {
 		}()
 	}
 
-	cchan := make(chan os.Signal)
-	signal.Notify(cchan, syscall.SIGTERM, syscall.SIGINT)
-
-	go func() {
-		<-cchan
-
-		stop()
-	}()
+	bindSignals(stop, syscall.SIGTERM, syscall.SIGINT)
 
 	wg.Wait()
 
 	return nil
+}
+
+func bindSignals(fn func(), ss ...os.Signal) {
+	ntfy := make(chan os.Signal, 1)
+	signal.Notify(ntfy, ss...)
+
+	go func() {
+		<-ntfy
+		fn()
+	}()
 }
 
 type polyWatcher struct {

--- a/pw.example.yml
+++ b/pw.example.yml
@@ -25,6 +25,6 @@ watchers:
       timeout: 3s
     cmd: 
       shell: /bin/sh -c
-      exec: dlv debug --headless -l :2345 --api-version=2 --accept-multiclient --log --continue ./cmd/api
+      exec: go mod tidy; dlv debug --headless -l :2345 --api-version=2 --accept-multiclient --log --continue ./cmd/api
       env: 
-        - GO111MODULE=off
+        - LOG_LEVEL=DEBUG

--- a/pw.example.yml
+++ b/pw.example.yml
@@ -25,6 +25,7 @@ watchers:
       timeout: 3s
     cmd: 
       shell: /bin/sh -c
-      exec: go mod tidy; dlv debug --headless -l :2345 --api-version=2 --accept-multiclient --log --continue ./cmd/api
+      exec: >
+        go mod tidy; dlv debug --headless -l :2345 --api-version=2 --accept-multiclient --log --continue ./cmd/api
       env: 
         - LOG_LEVEL=DEBUG


### PR DESCRIPTION
with this changes we are able to use go modules inside docker container. and we can handle TERMINATE and INTERRUPT signals to gracefully close watchers.